### PR TITLE
Remove expose extras

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,6 @@
     "silverstripe/framework": "^4.0 || ^5.0",
     "dnadesign/silverstripe-elemental": "^4.0 || ^5.0"
   },
-  "extra": {
-    "expose": [
-      "client"
-    ]
-  },
   "autoload": {
     "psr-4": {
       "Sunnysideup\\ElementalToc\\": "src/"


### PR DESCRIPTION
There are no files to expose, so therefore, it should not be in the composer.json file.